### PR TITLE
feat: bring keymap to parity+ with QMK

### DIFF
--- a/config/murphpad.keymap
+++ b/config/murphpad.keymap
@@ -36,7 +36,7 @@
         combo_reset {
             timeout-ms = <TIMEOUT>;
             key-positions = <1 3>;
-            bindings = <&reset>;
+            bindings = <&sys_reset>;
         };
         combo_bootloader {
             timeout-ms = <TIMEOUT>;

--- a/config/murphpad.keymap
+++ b/config/murphpad.keymap
@@ -7,6 +7,7 @@
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/outputs.h>
 #include <dt-bindings/zmk/rgb.h>
 
 #define TIMEOUT 300
@@ -15,13 +16,12 @@
 #define DEFAULT 0
 #define FN      1
 
-
 &encoder_1 {
-	status = "okay";
+    status = "okay";
 };
 
 &encoder_2 {
-	status = "okay";
+    status = "okay";
 };
 
 /* Combo Definitions*/
@@ -50,40 +50,40 @@
         };
     };
 
-	sensors {
-		compatible = "zmk,keymap-sensors";
-		sensors = <&encoder_1 &encoder_2>;
-	};
+    sensors {
+        compatible = "zmk,keymap-sensors";
+        sensors = <&encoder_1 &encoder_2>;
+    };
 
 
-	keymap0: keymap {
-		compatible = "zmk,keymap";
+    keymap0: keymap {
+        compatible = "zmk,keymap";
 
-		default_layer {
-		label = "default layer";
+        default_layer {
+        label = "default layer";
             bindings = <
-                &bt BT_CLR       &kp TAB      &kp F5          &kp LC(LA(C))     &kp LG(D)   
-                &rgb_ug RGB_TOG  &kp ESC      &kp KP_DIVIDE   &kp KP_MULTIPLY   &kp KP_MINUS    
-                &rgb_ug RGB_EFF  &kp KP_N7    &kp KP_N8       &kp KP_N9         &kp KP_PLUS   
+                &bt BT_CLR       &kp F1       &kp F2          &kp F3            &kp F4
+                &rgb_ug RGB_TOG  &kp KP_NUM   &kp KP_DIVIDE   &kp KP_MULTIPLY   &kp KP_MINUS
+                &rgb_ug RGB_EFF  &kp KP_N7    &kp KP_N8       &kp KP_N9         &kp KP_PLUS
                 &kp C_MUTE       &kp KP_N4    &kp KP_N5       &kp KP_N6         &trans
-                &mo 1            &kp KP_N1    &kp KP_N2       &kp KP_N3         &kp KP_ENTER
+                &mo FN           &kp KP_N1    &kp KP_N2       &kp KP_N3         &kp KP_ENTER
                 &kp BSPC         &kp KP_N0    &trans          &kp KP_DOT        &trans
             >;
-			sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
+            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
 
-        }; 
+        };
 
         fn_layer {
-		label = "fn layer";
+        label = "fn layer";
             bindings = <
-                &trans      &trans     &trans        &trans          &trans  
-                &trans      &kp KP_NUM &trans        &trans          &trans     
-                &trans      &trans     &trans        &trans	         &trans
-                &bt BT_CLR  &trans     &trans        &trans          &trans    
-                &trans      &trans     &trans        &trans          &trans
-                &kp DEL    	&trans     &trans        &trans          &trans           
-            >;  
-			sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp C_VOL_UP C_VOL_DN>;
+                &trans      &out OUT_TOG     &bt BT_PRV       &bt BT_NXT       &trans
+                &trans      &trans           &trans           &trans           &trans
+                &trans      &rgb_ug RGB_HUD  &rgb_ug RGB_SPI  &rgb_ug RGB_HUI  &trans
+                &bt BT_CLR  &rgb_ug RGB_EFR  &rgb_ug RGB_TOG  &rgb_ug RGB_EFF  &trans
+                &trans      &rgb_ug RGB_BRD  &rgb_ug RGB_SPD  &rgb_ug RGB_BRI  &trans
+                &kp DEL     &rgb_ug RGB_SAD  &trans           &rgb_ug RGB_SAI  &trans
+            >;
+            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
 
         };
     };


### PR DESCRIPTION
@heytimbe asked me what `LC(LA(C))` was used for in the MurphPad ZMK keymap, and I was very confused.

It's probably better to have the QMK and ZMK keymaps align where it makes sense. `&out OUT_TOG` and an upfront way to switch between BT profiles is likely to cut down on questions.